### PR TITLE
Fixes icon line hight

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -16,6 +16,8 @@ core-scaffold::shadow core-toolbar {
 }
 core-icon[icon=account-circle] {
     margin-right: 3px;
+    align-self: flex-end;
+    -webkit-align-self: flex-end;
 }
 paper-input {
     padding-right: 10px;


### PR DESCRIPTION
This would fix the line hight of the icon next to the "connected" text.

Before:
![image](https://cloud.githubusercontent.com/assets/5961995/6728385/d1f2a51c-ce29-11e4-981d-ceb507a16b15.png)


After:
![image](https://cloud.githubusercontent.com/assets/5961995/6728377/b8ec42e4-ce29-11e4-9771-7f8b3931f131.png)
