### PR TITLE
Update node version to 4.8.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "slack-utils": "^0.3.0"
   },
   "engines": {
-    "node": "0.10.x"
+    "node": "4.8.5"
   }
 }


### PR DESCRIPTION
Installing showdown library gives this error:
`
npm WARN engine showdown-htmlescape@0.1.9: wanted: {"node":">= 4.0"} (current: {"node":"0.10.48","npm":"2.15.1"})
`